### PR TITLE
add receptor_install_method

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The name of the control socket file.
 
 ---
 
-    receptor_config_path: '/etc/receptor'
+    receptor_config_dir: '/etc/receptor'
 
 Path to the Receptor config file.
 
@@ -216,16 +216,18 @@ for more information.
 
 ---
 
-    local_receptor: false
+    receptor_install_method: package
 
-Set to true to upload a local receptor binary instead of installing via a package manager. If no local binary is present, it will be downloaded from receptor Releases on github.
-For Debian we set it a true as default.
+Options are 'package', 'local', or 'release'
+If 'package', will use the os-specific package manager to install receptor.
+If 'local', will upload a local receptor binary. To be paired with `local_receptor_bin_file`.
+If 'release', the receptor binary will be downloaded from receptor Releases on github.
 
 ---
 
 ---
 
-    local_receptor_path: '/tmp/receptor-bin'
+    local_receptor_bin_file: '/tmp/receptor-bin'
 
 Path of local receptor binary.
 
@@ -241,7 +243,7 @@ Receptor binary path on remote node.
 
 ---
 
-    receptor_path_log: '/var/log/receptor'
+    receptor_log_dir: '/var/log/receptor'
 
 Receptor log directory. Used only when local_receptor is true.
 
@@ -251,7 +253,7 @@ Receptor log directory. Used only when local_receptor is true.
 
     receptor_github_owner: 'ansible'
 
-Owner of github repo where we search and download package if local_receptor_path not exists.
+Owner of github repo where we search and download package if local_receptor_bin_file not exists.
 
 ---
 
@@ -259,7 +261,7 @@ Owner of github repo where we search and download package if local_receptor_path
 
     receptor_github_repo: 'receptor'
 
-Repository github where we search and download package if local_receptor_path not exists.
+Repository github where we search and download package if local_receptor_bin_file not exists.
 
 ---
 
@@ -267,7 +269,7 @@ Repository github where we search and download package if local_receptor_path no
 
     receptor_github_release: # not set, if set we use it for download package
 
-Repository version where we search and download package if local_receptor_path not exists.
+Repository version where we search and download package if local_receptor_bin_file not exists.
 
 ---
 

--- a/roles/podman/tasks/variables.yml
+++ b/roles/podman/tasks/variables.yml
@@ -1,5 +1,5 @@
 ---
-- name: Include OS-specific variables (RedHat)
+- name: Include OS-specific variables "{{ ansible_os_family }}"
   ansible.builtin.include_vars: "{{ ansible_os_family }}.yml"
   when:
     - ansible_os_family in ['RedHat', 'Debian']

--- a/roles/setup/README.md
+++ b/roles/setup/README.md
@@ -42,7 +42,7 @@ The name of the control socket file.
 
 ---
 
-    receptor_config_path: '/etc/receptor'
+    receptor_config_dir: '/etc/receptor'
 
 Path to the Receptor config file.
 
@@ -214,16 +214,18 @@ for more information.
 
 ---
 
-    local_receptor: false
+    receptor_install_method: package
 
-Set to true to upload a local receptor binary instead of installing via a package manager. If no local binary is present, it will be downloaded from receptor Releases on github.
-For Debian we set it a true as default.
+Options are 'package', 'local', or 'release'
+If 'package', will use the os-specific package manager to install receptor.
+If 'local', will upload a local receptor binary. To be paired with `local_receptor_bin_file`.
+If 'release', the receptor binary will be downloaded from receptor Releases on github.
 
 ---
 
 ---
 
-    local_receptor_path: '/tmp/receptor-bin'
+    local_receptor_bin_file: '/tmp/receptor-bin'
 
 Path of local receptor binary.
 
@@ -239,7 +241,7 @@ Receptor binary path on remote node.
 
 ---
 
-    receptor_path_log: '/var/log/receptor'
+    receptor_log_dir: '/var/log/receptor'
 
 Receptor log directory. Used only when local_receptor is true.
 
@@ -249,7 +251,7 @@ Receptor log directory. Used only when local_receptor is true.
 
     receptor_github_owner: 'ansible'
 
-Owner of github repo where we search and download package if local_receptor_path not exists.
+Owner of github repo where we search and download package if local_receptor_bin_file not exists.
 
 ---
 
@@ -257,7 +259,7 @@ Owner of github repo where we search and download package if local_receptor_path
 
     receptor_github_repo: 'receptor'
 
-Repository github where we search and download package if local_receptor_path not exists.
+Repository github where we search and download package if local_receptor_bin_file not exists.
 
 ---
 
@@ -265,7 +267,7 @@ Repository github where we search and download package if local_receptor_path no
 
     receptor_github_release: # not set, if set we use it for download package
 
-Repository release where we search and download package if local_receptor_path not exists.
+Repository release where we search and download package if local_receptor_bin_file not exists.
 
 ---
 

--- a/roles/setup/defaults/main.yml
+++ b/roles/setup/defaults/main.yml
@@ -2,7 +2,7 @@
 receptor_user: receptor
 receptor_group: receptor
 
-receptor_config_path: '/etc/receptor'
+receptor_config_dir: '/etc/receptor'
 receptor_socket_dir: '/var/run/receptor'
 receptor_control_filename: 'receptor.sock'
 
@@ -36,14 +36,14 @@ receptor_log_level: 'info'
 _hostname: "{{ routable_hostname | default(ansible_host) }}"
 receptor_host_identifier: "{{ (_hostname == 'localhost') | ternary('localhost.localdomain', _hostname) }}"
 
-local_receptor: false
-local_receptor_path: '/tmp/receptor-bin'
+receptor_install_method: package # options: local, release
+local_receptor_bin_file: ''
 receptor_install_dir: '/usr/bin'
 
 receptor_github_owner: ansible
 receptor_github_repo: receptor
 
-receptor_path_log: /var/log/receptor
+receptor_log_dir: /var/log/receptor
 
 receptor_service_name: receptor
 arch_mapping:

--- a/roles/setup/tasks/main.yml
+++ b/roles/setup/tasks/main.yml
@@ -7,7 +7,13 @@
   when: ansible_os_family in ['RedHat', 'Debian']
 
 - include_tasks: "setup-local.yml"
-  when: local_receptor
+  when: receptor_install_method == 'local'
+
+- include_tasks: "setup-release.yml"
+  when: receptor_install_method == 'release'
+
+- include_tasks: "setup-service.yml"
+  when: receptor_install_method in ['release', 'local']
 
 - name: Check if receptor was installed correctly
   ansible.builtin.command: "receptor --version"
@@ -33,7 +39,7 @@
 - name: Deploy receptor config
   ansible.builtin.template:
     src: templates/receptor.conf.j2
-    dest: "{{ receptor_config_path }}/receptor.conf"
+    dest: "{{ receptor_config_dir }}/receptor.conf"
     mode: '0644'
     owner: "{{ receptor_user }}"
     group: "{{ receptor_group }}"

--- a/roles/setup/tasks/setup-RedHat.yml
+++ b/roles/setup/tasks/setup-RedHat.yml
@@ -3,7 +3,7 @@
   ansible.builtin.dnf:
     name: "{{ receptor_packages }}"
     state: present
-  when: not local_receptor
+  when: receptor_install_method == 'package'
 
 - name: Install dependencies specific to the node type
   ansible.builtin.dnf:

--- a/roles/setup/tasks/setup-local.yml
+++ b/roles/setup/tasks/setup-local.yml
@@ -1,85 +1,21 @@
 ---
-# if bin not exists we download it from github repo/tag
-
-- name: Check in {{ local_receptor_path }}/receptor exist
+- name: Stat local binary
+  delegate_to: localhost
+  become: false
   ansible.builtin.stat:
-    path: "{{ local_receptor_path }}/receptor"
-  register: local_receptor_stat
+    path: "{{ local_receptor_bin_file }}"
+  register: bin
 
-- name: Download receptor bin from github
-  block:
-    - name: Create local receptor path
-      ansible.builtin.file:
-        path: "{{ local_receptor_path }}"
-        state: directory
-        mode: '0644'
-
-    - name: Get latest release of receptor repository
-      ansible.builtin.uri:
-        url: "https://api.github.com/repos/{{ receptor_github_owner }}/\
-          {{ receptor_github_repo }}/releases/latest"
-      register: latest_receptor_release
-
-    - name: Set receptor downloads facts
-      ansible.builtin.set_fact:
-        receptor_tag: "{{ (receptor_github_release |
-          default(latest_receptor_release.json.tag_name)) }}"
-        receptor_arch: "{{ arch_mapping[ansible_architecture] | default(ansible_architecture) }}"
-
-    - name: Download receptor from {{ receptor_tag }} release
-      ansible.builtin.get_url:
-        url: "https://github.com/{{ receptor_github_owner }}/\
-          {{ receptor_github_repo }}/releases/\
-          download/{{ receptor_tag }}/{{ receptor_github_repo }}_\
-          {{ receptor_tag | regex_replace('^v', '') }}_{{ ansible_system | lower }}_{{ receptor_arch }}.tar.gz"
-        dest: "{{ local_receptor_path }}"
-        mode: '0644'
-
-    - name: Unarchive receptor release
-      ansible.builtin.unarchive:
-        src: "{{ local_receptor_path }}/{{ receptor_github_repo }}_\
-          {{ receptor_tag | regex_replace('^v', '') }}_{{ ansible_system | lower }}_{{ receptor_arch }}.tar.gz"
-        dest: "{{ receptor_install_dir }}"
-        remote_src: true
-
-    - name: Remove receptor archive
-      ansible.builtin.file:
-        path: "{{ local_receptor_path }}/{{ receptor_github_repo }}_\
-          {{ receptor_tag | regex_replace('^v', '') }}_{{ ansible_system | lower }}_{{ receptor_arch }}.tar.gz"
-        state: absent
-
-  when: not local_receptor_stat.stat.exists
+- name: Assert binary is file
+  ansible.builtin.assert:
+    that:
+      - bin.stat.exists == True
+      - bin.stat.isdir is defined and bin.stat.isdir == False
 
 - name: Copy receptor's build to "{{ receptor_install_dir }}"
   ansible.builtin.copy:
-    src: "{{ local_receptor_path }}/receptor"
+    src: "{{ local_receptor_bin_file }}"
     dest: "{{ receptor_install_dir }}/receptor"
     owner: root
     group: root
     mode: 'u=rwx,go=rx'
-    remote_src: true
-  when: local_receptor_stat.stat.exists
-
-- name: Add receptor's path to profile
-  ansible.builtin.copy:
-    dest: /etc/profile.d/receptor.sh
-    content: "PATH=$PATH:{{ receptor_install_dir }}/receptor"
-    owner: root
-    group: root
-    mode: 'u=rwx,go=rx'
-
-- name: Create receptor's log folder
-  ansible.builtin.file:
-    path: "{{ receptor_path_log }}"
-    state: directory
-    owner: root
-    group: root
-    mode: '0755'
-
-- name: Create receptor's systemd service
-  ansible.builtin.template:
-    src: templates/systemd_receptor.service.j2
-    dest: "{{ systemd_folder }}/receptor.service"
-    mode: '0644'
-    owner: root
-    group: root

--- a/roles/setup/tasks/setup-release.yml
+++ b/roles/setup/tasks/setup-release.yml
@@ -1,0 +1,38 @@
+---
+- name: Create temp directory for tar gz file
+  ansible.builtin.tempfile:
+    state: directory
+  register: tmpdir
+
+- name: Get latest release of receptor repository
+  ansible.builtin.uri:
+    url: "https://api.github.com/repos/{{ receptor_github_owner }}/\
+      {{ receptor_github_repo }}/releases/latest"
+  register: latest_receptor_release
+
+- name: Set receptor downloads facts
+  ansible.builtin.set_fact:
+    receptor_tag: "{{ (receptor_github_release |
+      default(latest_receptor_release.json.tag_name)) }}"
+    receptor_arch: "{{ arch_mapping[ansible_architecture] | default(ansible_architecture) }}"
+
+- name: Download receptor from {{ receptor_tag }} release
+  ansible.builtin.get_url:
+    url: "https://github.com/{{ receptor_github_owner }}/\
+      {{ receptor_github_repo }}/releases/\
+      download/{{ receptor_tag }}/{{ receptor_github_repo }}_\
+      {{ receptor_tag | regex_replace('^v', '') }}_{{ ansible_system | lower }}_{{ receptor_arch }}.tar.gz"
+    dest: "{{ tmpdir.path }}"
+    mode: '0644'
+
+- name: Unarchive receptor release
+  ansible.builtin.unarchive:
+    src: "/{{ tmpdir.path }}/{{ receptor_github_repo }}_\
+      {{ receptor_tag | regex_replace('^v', '') }}_{{ ansible_system | lower }}_{{ receptor_arch }}.tar.gz"
+    dest: "{{ receptor_install_dir }}"
+    remote_src: true
+
+- name: Remove receptor archive
+  ansible.builtin.file:
+    path: "{{ tmpdir.path }}"
+    state: absent

--- a/roles/setup/tasks/setup-service.yml
+++ b/roles/setup/tasks/setup-service.yml
@@ -1,0 +1,24 @@
+---
+- name: Add receptor's path to profile
+  ansible.builtin.copy:
+    dest: /etc/profile.d/receptor.sh
+    content: "PATH=$PATH:{{ receptor_install_dir }}/receptor"
+    owner: root
+    group: root
+    mode: 'u=rwx,go=rx'
+
+- name: Create receptor's log folder
+  ansible.builtin.file:
+    path: "{{ receptor_log_dir }}"
+    state: directory
+    owner: root
+    group: root
+    mode: '0755'
+
+- name: Create receptor's systemd service
+  ansible.builtin.template:
+    src: templates/systemd_receptor.service.j2
+    dest: "{{ systemd_folder }}/receptor.service"
+    mode: '0644'
+    owner: root
+    group: root

--- a/roles/setup/tasks/variables.yml
+++ b/roles/setup/tasks/variables.yml
@@ -1,5 +1,5 @@
 ---
-- name: Include OS-specific variables
+- name: Include OS-specific variables "{{ ansible_os_family }}"
   ansible.builtin.include_vars: "{{ ansible_os_family }}.yml"
   when:
     - ansible_os_family in ['RedHat', 'Debian']

--- a/roles/setup/templates/systemd_receptor.service.j2
+++ b/roles/setup/templates/systemd_receptor.service.j2
@@ -4,8 +4,8 @@ After=network.target
 StartLimitIntervalSec=0
 
 [Service]
-ExecStart={{ receptor_install_dir }}/receptor --config {{ receptor_config_path }}/receptor.conf
-StandardOutput=append:{{ receptor_path_log }}/receptor.log
+ExecStart={{ receptor_install_dir }}/receptor --config {{ receptor_config_dir }}/receptor.conf
+StandardOutput=append:{{ receptor_log_dir }}/receptor.log
 Restart=on-failure
 
 [Install]

--- a/roles/setup/vars/Debian.yml
+++ b/roles/setup/vars/Debian.yml
@@ -1,4 +1,4 @@
 ---
 __receptor_packages: []
 systemd_folder: "/lib/systemd/system"
-local_receptor: true   # required beacuse on debian machine no package receptor exists
+receptor_install_method: 'release'   # required beacuse on debian machine no package receptor exists


### PR DESCRIPTION
Instead of `local_receptor` and falling back to downloading if local_receptor_binary doesn't exist, I want to make it more clear which method of installation will be used.

Refactor:
- move github downloading block to setup-release.yml
- move service config file and receptor logging logic to setup-service.yml

New variable
- `receptor_install_method` can be `local`, `package`, or `release`
- setup-local.yml now only runs if install method is `local`
- setup-release.yml runs if install method is `release`
- setup-service.yml sets up the service file and logging file and will run if `local` or `release` is used

other changes:
- rename `local_receptor_path` to `local_receptor_bin_file` to be more clear that it is a file
- `local_receptor_bin_file` should point to exact binary file, and we shouldn't define a default to prevent unintended binaries to be uploaded
- more consistent variables names. `_dir` should be used if value is expected to be a directory. And `file` should be in the name if variable is supposed to be the full path.

Tested the following scenarios by launching jobs against them:

- [x] RHEL9 with 'package'
- [x] RHEL9 with 'release'
- [x] RHEL9 with 'local'
- [x] Debian with 'release'